### PR TITLE
Type definitions for iso-3166-1

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,13 @@
+// Type definitions for iso-3166-1
+// Project: https://github.com/lukealbao/iso-3166-1
+// Definitions by: Bruno Finger <https://github.com/brunofin>
+
+// usage: import * as iso3166 from 'iso-3166';
+
+declare module "iso-3166" {
+    export function numeric(input: string): string;
+    export function alpha2(input: string): string;
+    export function alpha3(input: string): string;
+    export function name(input: string): string;
+    export function currency(input: string): string;
+}


### PR DESCRIPTION
Adds TypeScript Type definitions for iso-3166-1.

![image](https://user-images.githubusercontent.com/8077237/51486081-e4070800-1d86-11e9-8a48-4e32fbabec18.png)
